### PR TITLE
[ci] Update github actions to v4

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -37,7 +37,7 @@ jobs:
         NEXT_PUBLIC_MUI_GRID_LICENSE: ${{ secrets.NEXT_PUBLIC_MUI_GRID_LICENSE }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # Perform a deep clone (fetch all history)

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -37,7 +37,7 @@ jobs:
         NEXT_PUBLIC_MUI_GRID_LICENSE: ${{ secrets.NEXT_PUBLIC_MUI_GRID_LICENSE }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # Perform a deep clone (fetch all history)

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -31,7 +31,7 @@ jobs:
         NEXT_PUBLIC_MUI_GRID_LICENSE: ${{ secrets.NEXT_PUBLIC_MUI_GRID_LICENSE }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # Perform a deep clone (fetch all history)

--- a/.github/workflows/playwright.perf.yml
+++ b/.github/workflows/playwright.perf.yml
@@ -39,7 +39,7 @@ jobs:
         CI: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Disable shallow clone
       - name: Install dependencies

--- a/.github/workflows/playwright.smoke.yml
+++ b/.github/workflows/playwright.smoke.yml
@@ -39,7 +39,7 @@ jobs:
         CI: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Disable shallow clone
       - name: Install dependencies
@@ -57,7 +57,7 @@ jobs:
           CLOUDFLARE_PROTECTED_API_CLIENT_ID: ${{ secrets.CLOUDFLARE_PROTECTED_API_CLIENT_ID }}
           CLOUDFLARE_PROTECTED_API_CLIENT_SECRET: ${{ secrets.CLOUDFLARE_PROTECTED_API_CLIENT_SECRET }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -43,7 +43,7 @@ jobs:
         CI: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Disable shallow clone
       - name: Install dependencies
@@ -61,7 +61,7 @@ jobs:
           CLOUDFLARE_PROTECTED_API_CLIENT_ID: ${{ secrets.CLOUDFLARE_PROTECTED_API_CLIENT_ID }}
           CLOUDFLARE_PROTECTED_API_CLIENT_SECRET: ${{ secrets.CLOUDFLARE_PROTECTED_API_CLIENT_SECRET }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: playwright-report


### PR DESCRIPTION
This PR upgrades Github Actions to v4, as the following workflows are scheduled for deprecation and will be removed by December 5th, 2024:
- `actions/upload-artifact`
- `actions/download-artifact`

Reference: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/


<!-- ClickUpRef: 8696qn0bh -->
:link: [zboto Link](https://app.clickup.com/t/8696qn0bh)